### PR TITLE
Typo in fabric.mod.json

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -3,7 +3,7 @@
 	"id": "create-storage-dimension",
 	"version": "${version}",
 	"name": "Create Storage Dimension",
-	"description": "A Create Mod addon that adds a potentially OP storage system, available to be accessed from anywhere, and a backpack system, which can have many upgrades. inspired by Sophisticated Backpacks, Storage Drawers, and Appled Energistics 2.",
+	"description": "A Create Mod addon that adds a potentially OP storage system, available to be accessed from anywhere, and a backpack system, which can have many upgrades. inspired by Sophisticated Backpacks, Storage Drawers, and Applied Energistics 2.",
 	"authors": [
 		"JaFu.py"
 	],


### PR DESCRIPTION
Hi!
I found a typo in your `fabric.mod.json` file.
This PR changes the typo "Appled Energistics" to "Appl**i**ed Energistics", nothing else.
Hope I could help!